### PR TITLE
Fixed issue with assets precompilation

### DIFF
--- a/app/assets/stylesheets/rails_settings_ui/application.css.scss
+++ b/app/assets/stylesheets/rails_settings_ui/application.css.scss
@@ -1,4 +1,4 @@
 /*
- *= require bootstrap_and_overrides
+ *= require ./bootstrap_and_overrides
  *= require_self
 */


### PR DESCRIPTION
```
rake aborted!
couldn't find file 'bootstrap_and_overrides'
  (in /Users/user/.rvm/gems/ruby-2.1.1/bundler/gems/rails-settings-ui-293f9140b76e/app/assets/stylesheets/rails_settings_ui/application.css.scss:2)
/Users/user/.rvm/gems/ruby-2.1.1/gems/sprockets-2.11.0/lib/sprockets/context.rb:106:in `resolve'
/Users/user/.rvm/gems/ruby-2.1.1/gems/sprockets-2.11.0/lib/sprockets/context.rb:146:in `require_asset'
```
