### PR TITLE
Fix for non-existent Settings.defaults. 

### DIFF
--- a/app/controllers/rails_settings_ui/settings_controller.rb
+++ b/app/controllers/rails_settings_ui/settings_controller.rb
@@ -18,21 +18,20 @@ class RailsSettingsUi::SettingsController < RailsSettingsUi::ApplicationControll
   private
 
   def collection
-    all_settings = default_settings.merge(RailsSettingsUi.settings_klass.public_send(get_collection_method))
     all_settings_without_ignored = all_settings.reject{ |name, description| RailsSettingsUi.ignored_settings.include?(name.to_sym) }
     @settings = Hash[all_settings_without_ignored]
     @errors = {}
   end
 
   def validate_settings
-    @errors = RailsSettingsUi::SettingsFormValidator.new(default_settings, params['settings'].deep_dup).errors
+    @errors = RailsSettingsUi::SettingsFormValidator.new(all_settings, params['settings'].deep_dup).errors
   end
 
   def coerced_values
-    RailsSettingsUi::SettingsFormCoercible.new(default_settings, params['settings'].deep_dup).coerce!
+    RailsSettingsUi::SettingsFormCoercible.new(all_settings, params['settings'].deep_dup).coerce!
   end
 
-  def default_settings
-    RailsSettingsUi.settings_klass.defaults
+  def all_settings
+    RailsSettingsUi.settings_klass.get_all
   end
 end

--- a/app/helpers/rails_settings_ui/settings_helper.rb
+++ b/app/helpers/rails_settings_ui/settings_helper.rb
@@ -1,8 +1,6 @@
 module RailsSettingsUi::SettingsHelper
   def setting_field(setting_name, setting_value, all_settings)
-    if !RailsSettingsUi.settings_klass.defaults.has_key?(setting_name.to_sym)
-      message_for_default_value_missing
-    elsif RailsSettingsUi.settings_displayed_as_select_tag.include?(setting_name.to_sym)
+    if RailsSettingsUi.settings_displayed_as_select_tag.include?(setting_name.to_sym)
       select_tag_field(setting_name, setting_value)
     elsif setting_value.is_a?(Array)
       checkboxes_group_field(setting_name, all_settings)
@@ -22,7 +20,7 @@ module RailsSettingsUi::SettingsHelper
 
   def checkboxes_group_field(setting_name, all_settings)
     field = ""
-    RailsSettingsUi.settings_klass.defaults[setting_name.to_sym].each do |value|
+    RailsSettingsUi.settings_klass.get_all[setting_name.to_sym].each do |value|
       checked = all_settings[setting_name.to_s].map(&:to_s).include?(value.to_s)
       field << check_box_tag("settings[#{setting_name.to_s}][#{value.to_s}]", nil, checked, style: "margin: 0 10px;")
       field << label_tag("settings[#{setting_name.to_s}][#{value.to_s}]", I18n.t("settings.attributes.#{setting_name}.labels.#{value}", default: value.to_s), style: "display: inline-block;")


### PR DESCRIPTION
Quick fix: using Settings.get_all hash instead.
