### PR TITLE
fix displaying ActionController::Parameters value

### DIFF
--- a/app/controllers/rails_settings_ui/settings_controller.rb
+++ b/app/controllers/rails_settings_ui/settings_controller.rb
@@ -1,7 +1,7 @@
 class RailsSettingsUi::SettingsController < RailsSettingsUi::ApplicationController
   include RailsSettingsUi::SettingsHelper
-  before_filter :collection
-  before_filter :cast_settings_params, only: :update_all
+  before_action :collection
+  before_action :cast_settings_params, only: :update_all
 
   def index
   end

--- a/app/helpers/rails_settings_ui/settings_helper.rb
+++ b/app/helpers/rails_settings_ui/settings_helper.rb
@@ -42,6 +42,8 @@ module RailsSettingsUi::SettingsHelper
   end
 
   def text_field(setting_name, setting_value, options = {})
+    setting_value = setting_value.permit!.to_h if setting_value.is_a?(ActionController::Parameters)
+
     field = if setting_value.to_s.size > 30
       text_area_tag("settings[#{setting_name}]", setting_value.to_s, options.merge(rows: 10))
     else


### PR DESCRIPTION
This code use before commit accessd#32 to fix value display as `ActionController::Parameters` on text field using Rails 5.0.0