### PR TITLE
Enable saving of settings in the context of current user

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## v1.2.0
+
+* enable saving of settings in the context of current user
+
 ## v1.1.0
 
 * fix dry-rb and Rails 5 integration

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ In config/initializers/rails_settings_ui.rb
 
     RailsSettingsUi.setup do |config|
       config.ignored_settings = [:company_name] # Settings not displayed in the interface
-      config.settings_class = "MySettings" # Customize settings class name
+      config.settings_class = MySettings # Customize settings class name
+      config.current_user_context = true # Apply settings in context of current user
     end
 
 Routing

--- a/app/controllers/rails_settings_ui/application_controller.rb
+++ b/app/controllers/rails_settings_ui/application_controller.rb
@@ -1,4 +1,9 @@
 module RailsSettingsUi
   class ApplicationController < ::RailsSettingsUi.parent_controller.constantize
+
+    def current_user
+      @current_user
+    end
+
   end
 end

--- a/app/controllers/rails_settings_ui/settings_controller.rb
+++ b/app/controllers/rails_settings_ui/settings_controller.rb
@@ -10,7 +10,7 @@ class RailsSettingsUi::SettingsController < RailsSettingsUi::ApplicationControll
     if @errors.any?
       render :index
     else
-      coerced_values.each { |name, value| RailsSettingsUi.settings_klass[name] = value }
+      coerced_values.each { |name, value| settings[name] = value }
       redirect_to [:settings]
     end
   end
@@ -18,7 +18,7 @@ class RailsSettingsUi::SettingsController < RailsSettingsUi::ApplicationControll
   private
 
   def collection
-    all_settings = default_settings.merge(RailsSettingsUi.settings_klass.public_send(get_collection_method))
+    all_settings = default_settings.merge(settings.public_send(get_collection_method))
     all_settings_without_ignored = all_settings.reject{ |name, description| RailsSettingsUi.ignored_settings.include?(name.to_sym) }
     @settings = Hash[all_settings_without_ignored]
     @errors = {}
@@ -43,7 +43,15 @@ class RailsSettingsUi::SettingsController < RailsSettingsUi::ApplicationControll
     end
   end
 
+  def settings
+    if RailsSettingsUi.current_user_context
+      current_user.settings
+    else
+      RailsSettingsUi.settings_class
+    end
+  end
+
   def default_settings
-    RailsSettingsUi.settings_klass.defaults
+    RailsSettingsUi.settings_class.defaults
   end
 end

--- a/app/helpers/rails_settings_ui/settings_helper.rb
+++ b/app/helpers/rails_settings_ui/settings_helper.rb
@@ -17,10 +17,7 @@ module RailsSettingsUi::SettingsHelper
     default_setting_values = I18n.t("settings.attributes.#{setting_name}.labels", default: {}).map do |value, label|
       [label, value]
     end
-    field = select_tag("settings[#{setting_name.to_s}]", options_for_select(default_setting_values, setting_value), class: 'form-control')
-    help_block_content = I18n.t("settings.attributes.#{setting_name}.help_block", default: '')
-    field << content_tag(:span, help_block_content, class: 'help-block') if help_block_content.presence
-    field.html_safe
+    select_tag("settings[#{setting_name.to_s}]", options_for_select(default_setting_values, setting_value), class: 'form-control')
   end
 
   def checkboxes_group_field(setting_name, all_settings)
@@ -67,5 +64,4 @@ module RailsSettingsUi::SettingsHelper
       :get_all
     end
   end
-
 end

--- a/app/helpers/rails_settings_ui/settings_helper.rb
+++ b/app/helpers/rails_settings_ui/settings_helper.rb
@@ -17,7 +17,10 @@ module RailsSettingsUi::SettingsHelper
     default_setting_values = I18n.t("settings.attributes.#{setting_name}.labels", default: {}).map do |value, label|
       [label, value]
     end
-    select_tag("settings[#{setting_name.to_s}]", options_for_select(default_setting_values, setting_value), class: 'form-control')
+    field = select_tag("settings[#{setting_name.to_s}]", options_for_select(default_setting_values, setting_value), class: 'form-control')
+    help_block_content = I18n.t("settings.attributes.#{setting_name}.help_block", default: '')
+    field << content_tag(:span, help_block_content, class: 'help-block') if help_block_content.presence
+    field.html_safe
   end
 
   def checkboxes_group_field(setting_name, all_settings)
@@ -64,4 +67,5 @@ module RailsSettingsUi::SettingsHelper
       :get_all
     end
   end
+
 end

--- a/app/helpers/rails_settings_ui/settings_helper.rb
+++ b/app/helpers/rails_settings_ui/settings_helper.rb
@@ -1,6 +1,6 @@
 module RailsSettingsUi::SettingsHelper
   def setting_field(setting_name, setting_value, all_settings)
-    if !RailsSettingsUi.settings_klass.defaults.has_key?(setting_name.to_sym)
+    if !RailsSettingsUi.settings_class.defaults.has_key?(setting_name.to_sym)
       message_for_default_value_missing
     elsif RailsSettingsUi.settings_displayed_as_select_tag.include?(setting_name.to_sym)
       select_tag_field(setting_name, setting_value)
@@ -25,7 +25,7 @@ module RailsSettingsUi::SettingsHelper
 
   def checkboxes_group_field(setting_name, all_settings)
     field = ""
-    RailsSettingsUi.settings_klass.defaults[setting_name.to_sym].each do |value|
+    RailsSettingsUi.settings_class.defaults[setting_name.to_sym].each do |value|
       checked = all_settings[setting_name.to_s].map(&:to_s).include?(value.to_s)
       field << check_box_tag("settings[#{setting_name.to_s}][#{value.to_s}]", nil, checked, style: "margin: 0 10px;")
       field << label_tag("settings[#{setting_name.to_s}][#{value.to_s}]", I18n.t("settings.attributes.#{setting_name}.labels.#{value}", default: value.to_s), style: "display: inline-block;")

--- a/app/views/rails_settings_ui/settings/index.html.erb
+++ b/app/views/rails_settings_ui/settings/index.html.erb
@@ -31,9 +31,9 @@
           <% setting_with_error = @casted_settings && @casted_settings[:errors].include?(name) %>
           <div class="form-group <%= errors ? 'has-error' : '' %>">
             <%= setting_field(name, value, @settings) %>
-            <%- if errors.present? %>
-              <span class="help-block"><%= errors %></span>
-            <% end %>
+            <span class="help-block">
+              <%= errors %>
+            </span>
           </div>
         </td>
       </tr>

--- a/app/views/rails_settings_ui/settings/index.html.erb
+++ b/app/views/rails_settings_ui/settings/index.html.erb
@@ -31,9 +31,9 @@
           <% setting_with_error = @casted_settings && @casted_settings[:errors].include?(name) %>
           <div class="form-group <%= errors ? 'has-error' : '' %>">
             <%= setting_field(name, value, @settings) %>
-            <span class="help-block">
-              <%= errors %>
-            </span>
+            <%- if errors.present? %>
+              <span class="help-block"><%= errors %></span>
+            <% end %>
           </div>
         </td>
       </tr>

--- a/lib/rails-settings-ui.rb
+++ b/lib/rails-settings-ui.rb
@@ -21,6 +21,9 @@ module RailsSettingsUi
   mattr_accessor :settings_class
   self.settings_class = "Settings"
 
+  mattr_accessor :current_user_context
+  self.current_user_context = false
+
   class << self
     def inline_main_app_routes!
       ::RailsSettingsUi::ApplicationController.helper ::RailsSettingsUi::MainAppRouteDelegator
@@ -28,10 +31,6 @@ module RailsSettingsUi
 
     def setup
       yield self
-    end
-
-    def settings_klass
-      settings_class.constantize
     end
   end
 end

--- a/lib/rails-settings-ui/version.rb
+++ b/lib/rails-settings-ui/version.rb
@@ -1,3 +1,3 @@
 module RailsSettingsUi
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
If settings are to be saved in the context of `current_user`, specify an additional option `current_user_context` to be `true`.

`def current_user` can be overridden in your own `ApplicationController` to return a different variable than `@current_user`.

Also, collect `settings_class` as a class name constant, instead of a `string`. 
