### PR TITLE
Use dry-validation < 1.0

### DIFF
--- a/rails-settings-ui.gemspec
+++ b/rails-settings-ui.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 3.0'
   s.add_dependency 'i18n'
   s.add_dependency 'dry-types'
-  s.add_dependency 'dry-validation', '>= 0.12.0'
+  s.add_dependency 'dry-validation', '< 1.0'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rails-controller-testing'


### PR DESCRIPTION
Since dry-validation made breaking changes in its 1.0 release, so in order for this to keep working as-is constrain it to using the 0.x release.