### PR TITLE
Update use of Fixnum that was deprecated in Ruby 3.x

### DIFF
--- a/lib/rails-settings-ui/settings_form_coercible.rb
+++ b/lib/rails-settings-ui/settings_form_coercible.rb
@@ -45,7 +45,7 @@ module RailsSettingsUi
     COERCIONS_MAP = {
         String => Types::Coercible::String,
         Symbol => Types::CustomCoercions::Symbol,
-        (1.class == Integer ? Integer : Fixnum) => Types::Params::Integer,
+        Integer => Types::Params::Integer,
         ActiveSupport::HashWithIndifferentAccess => Types::CustomCoercions::Hash,
         ActiveSupport::Duration => Types::Params::Integer,
         Float => Types::Params::Float,

--- a/lib/rails-settings-ui/settings_form_validator.rb
+++ b/lib/rails-settings-ui/settings_form_validator.rb
@@ -20,7 +20,7 @@ module RailsSettingsUi
 
   class SettingsFormValidator
     VALIDATABLE_TYPES = {
-      (1.class == Integer ? Integer : Fixnum) => :int?,
+      Integer => :int?,
       Float => :float?,
       ActiveSupport::Duration => :int?,
       ActiveSupport::HashWithIndifferentAccess => :form_hash?

--- a/lib/rails-settings-ui/type_converter.rb
+++ b/lib/rails-settings-ui/type_converter.rb
@@ -14,7 +14,6 @@ module RailsSettingsUi
     VALUE_TYPES_MAP = {
       String => RailsSettingsUi::ValueTypes::String,
       Symbol => RailsSettingsUi::ValueTypes::Symbol,
-      Fixnum => RailsSettingsUi::ValueTypes::Fixnum,
       # ActiveSupport::HashWithIndifferentAccess => RailsSettingsUi::ValueTypes::Hash,
       ActiveSupport::Duration => RailsSettingsUi::ValueTypes::Float,
       Float => RailsSettingsUi::ValueTypes::Float,


### PR DESCRIPTION
Fixnum has been removed in Ruby 3.x, so without these changes you can't use this lib anymore.

P.s. I noticed no updated Gem has been published for a while, hope you can do so :)