### PR TITLE
Fix Ruby 3 constant lookup error

### DIFF
--- a/lib/rails-settings-ui/settings_form_coercible.rb
+++ b/lib/rails-settings-ui/settings_form_coercible.rb
@@ -42,10 +42,11 @@ module RailsSettingsUi
     attr_reader :settings, :default_settings
     attr_accessor :coerced_settings
 
+    integer_klass = defined?(Fixnum) ? Fixnum : Integer
     COERCIONS_MAP = {
         String => Types::Coercible::String,
         Symbol => Types::CustomCoercions::Symbol,
-        (1.class == Integer ? Integer : Fixnum) => Types::Params::Integer,
+        integer_klass => Types::Params::Integer,
         ActiveSupport::HashWithIndifferentAccess => Types::CustomCoercions::Hash,
         ActiveSupport::Duration => Types::Params::Integer,
         Float => Types::Params::Float,

--- a/lib/rails-settings-ui/settings_form_validator.rb
+++ b/lib/rails-settings-ui/settings_form_validator.rb
@@ -19,8 +19,9 @@ module RailsSettingsUi
   end
 
   class SettingsFormValidator
+    integer_klass = defined?(Fixnum) ? Fixnum : Integer
     VALIDATABLE_TYPES = {
-      (1.class == Integer ? Integer : Fixnum) => :int?,
+      integer_klass => :int?,
       Float => :float?,
       ActiveSupport::Duration => :int?,
       ActiveSupport::HashWithIndifferentAccess => :form_hash?

--- a/lib/rails-settings-ui/type_converter.rb
+++ b/lib/rails-settings-ui/type_converter.rb
@@ -11,10 +11,11 @@ module RailsSettingsUi
   class UnknownDefaultValueType < StandardError;end
 
   class TypeConverter
+    integer_klass = defined?(Fixnum) ? Fixnum : Integer
     VALUE_TYPES_MAP = {
       String => RailsSettingsUi::ValueTypes::String,
       Symbol => RailsSettingsUi::ValueTypes::Symbol,
-      Fixnum => RailsSettingsUi::ValueTypes::Fixnum,
+      integer_klass => RailsSettingsUi::ValueTypes::Fixnum,
       # ActiveSupport::HashWithIndifferentAccess => RailsSettingsUi::ValueTypes::Hash,
       ActiveSupport::Duration => RailsSettingsUi::ValueTypes::Float,
       Float => RailsSettingsUi::ValueTypes::Float,


### PR DESCRIPTION
## Summary
- fix Ruby 3 compatibility when mapping numeric types

## Testing
- `bundle exec rspec` *(fails: private method `warn` called for ActiveSupport::Deprecation:Class)*

------
https://chatgpt.com/codex/tasks/task_e_684e7aa1dfb08327a2bec793828991c3