### PR TITLE
Fix spec load error with Rails 6

### DIFF
--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -6,6 +6,8 @@ require File.expand_path('../boot', __FILE__)
 # require "action_mailer/railtie"
 # require "sprockets/railtie"
 
+# Workaround for Rails 6 requiring Logger before ActiveSupport modules
+require 'logger'
 require 'rails/all'
 # require "rails/test_unit/railtie"
 

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -33,4 +33,9 @@ Dummy::Application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+
+  # Allow unsafe YAML loading for tests with Rails >= 6
+  if defined?(ActiveRecord::Base) && ActiveRecord::Base.respond_to?(:use_yaml_unsafe_load=)
+    ActiveRecord::Base.use_yaml_unsafe_load = true
+  end
 end


### PR DESCRIPTION
## Summary
- require `logger` before `rails/all` in dummy application
- allow YAML unsafe load for tests when supported

## Testing
- `BUNDLE_GEMFILE=gemfiles/Gemfile-6-0 bundle exec rspec` *(fails: Psych::DisallowedClass)*
- `BUNDLE_GEMFILE=gemfiles/Gemfile-6-1 bundle exec rspec` *(fails: Psych::DisallowedClass)*
- `BUNDLE_GEMFILE=gemfiles/Gemfile-7-0 bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_684e8a91b6248327bd45acc94b697032