### PR TITLE
Add Rails 8 gemfile and CI test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - ruby: 3.3
+            gemfile: gemfiles/Gemfile-8-0
           - ruby: 3.1
             gemfile: gemfiles/Gemfile-7-0
           - ruby: 3.0.0

--- a/gemfiles/Gemfile-8-0
+++ b/gemfiles/Gemfile-8-0
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 8.0.0"
+gem "rails-settings-cached", "2.8.2"
+gem "sqlite3", ">= 2.1"
+
+gemspec path: ".."


### PR DESCRIPTION
## Summary
- add Rails 8.0 test Gemfile with sqlite3 2.x requirement
- test Rails 8 on Ruby 3.3 in CI matrix

## Testing
- `bundle exec rspec`
- `BUNDLE_GEMFILE=gemfiles/Gemfile-8-0 bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_684e8dd1bd688327975dd8c6697a93db