### PR TITLE
Fix locale typo

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,6 @@ en:
       value: Value
       save_all: Save all
       settings_include_errors: Settings include errors
-      settings_saved: Settings saved succesfully!
+      settings_saved: Settings saved successfully!
     errors:
       default_missing: Default value missing, but exists in db


### PR DESCRIPTION
## Summary
- fix typo in English locale file for settings saved message

## Testing
- `bundle exec rake spec`

------
https://chatgpt.com/codex/tasks/task_e_684e8f075cc88327956f49ceae404e3f